### PR TITLE
speedup ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,29 @@
-
 language: cpp
 os: osx
 osx_image: xcode8.2
-
+git:
+  depth: 1
 script:
   - cd ../
 
 # oF version 0.9.7
-  - git clone https://github.com/openframeworks/openFrameworks.git
-  - cd openframeworks/
-  - git checkout ee79e8bb6723380d3b6b794e81192d4035c1097b
-
-  - cd ../
-  - cp -r ToTheTop openFrameworks/apps/
+  - git clone -b 0.9.7 --depth 1 https://github.com/openframeworks/openFrameworks.git
+  - mv -r ToTheTop openFrameworks/apps/
 
 # CLONE ADDONS
 # ofxAnimatable
-  - git clone https://github.com/armadillu/ofxAnimatable.git
-  - cp -r ofxAnimatable openFrameworks/addons/
-
-# ofxImGui
-  - git clone https://github.com/jvcleave/ofxImGui.git
-  - cd ofxImGui/
-  - git checkout 5ae793b982a4542dd65b162682b76adf27e7f53a
-  - cd ../
-  - cp -r ofxImGui openFrameworks/addons/
-
+  - git clone --depth 1 https://github.com/armadillu/ofxAnimatable.git openFrameworks/addons/ofxAnimatable
+# ofxImGui version 1.49
+  - git clone -b 1.49 --depth 1 https://github.com/jvcleave/ofxImGui.git openFrameworks/addons/ofxImGui
 # ofxJSON
-  - git clone https://github.com/jefftimesten/ofxJSON.git
-  - cp -r ofxJSON openFrameworks/addons/
-
+  - git clone --depth 1 https://github.com/jefftimesten/ofxJSON.git openFrameworks/addons/ofxJSON
 # ofxSceneManager
-  - git clone https://github.com/Lacty/ofxSceneManager.git
-  - cp -r ofxSceneManager openFrameworks/addons/
-
+  - git clone --depth 1 https://github.com/Lacty/ofxSceneManager.git openFrameworks/addons/ofxSceneManager
 # ofxScreenCurtain
-  - git clone https://github.com/armadillu/ofxScreenCurtain.git
-  - cp -r ofxScreenCurtain openFrameworks/addons/
-
+  - git clone --depth 1 https://github.com/armadillu/ofxScreenCurtain.git openFrameworks/addons/ofxScreenCurtain
 # ofxJoystick
-  - git clone https://github.com/Lacty/ofxJoystick.git
-  - cp -r ofxJoystick openFrameworks/addons/
+  - git clone --depth 1 https://github.com/Lacty/ofxJoystick.git openFrameworks/addons/ofxJoystick
 
+# Build
   - cd openframeworks/apps/ToTheTop/
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 
 # oF version 0.9.7
   - git clone -b 0.9.7 --depth 1 https://github.com/openframeworks/openFrameworks.git
-  - mv -r ToTheTop openFrameworks/apps/
+  - mv ToTheTop openFrameworks/apps/
 
 # CLONE ADDONS
 # ofxAnimatable


### PR DESCRIPTION
# 要旨

いうまでもなくopenframeworksのgit repoなんてものは巨大であり、全部cloneしていたら日が暮れる。

そこで

- shallow clone
- ブランチやタグを指定してgit clone

することを提案する。

# git cloneのヘルプを見る

例えば

```sh
$git clone https://github.com/openframeworks/openFrameworks.git
```

のようにしているがこれは重い。そこで

```
NAME
       git-clone - Clone a repository into a new directory

SYNOPSIS
       git clone [--template=<template_directory>]
                 [-l] [-s] [--no-hardlinks] [-q] [-n] [--bare] [--mirror]
                 [-o <name>] [-b <name>] [-u <upload-pack>] [--reference <repository>]
                 [--dissociate] [--separate-git-dir <git dir>]
                 [--depth <depth>] [--[no-]single-branch]
                 [--recursive | --recurse-submodules] [--[no-]shallow-submodules]
                 [--jobs <n>] [--] <repository> [<directory>]
OPTIONS
       --branch <name>, -b <name>
           Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository’s HEAD, point to <name> branch instead. In a non-bare repository, this is the branch that
           will be checked out.  --branch can also take tags and detaches the HEAD at that commit in the resulting repository.
       --depth <depth>
           Create a shallow clone with a history truncated to the specified number of commits. Implies --single-branch unless --no-single-branch is given to fetch the histories near the tips of all
           branches. If you want to clone submodules shallowly, also pass --shallow-submodules.
```

manを覗くと、この2つの機能が有用そうである。

つまり

```sh
$git clone -b 0.9.7 --depth 1 https://github.com/openframeworks/openFrameworks.git
```

のようにする。

実行結果を比較してみよう。

```sh
$ git clone https://github.com/openframeworks/openFrameworks.git
Cloning into 'openFrameworks'...
remote: Counting objects: 132877, done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 132877 (delta 18), reused 0 (delta 0), pack-reused 132830
Receiving objects: 100% (132877/132877), 1.89 GiB | 18.45 MiB/s, done.
Resolving deltas: 100% (88206/88206), done.
Checking out files: 100% (3451/3451), done.
```

```sh
$git clone -b 0.9.7 --depth 1 https://github.com/openframeworks/openFrameworks.git
Cloning into 'openFrameworks'...
remote: Counting objects: 7024, done.
remote: Compressing objects: 100% (5110/5110), done.
remote: Total 7024 (delta 1746), reused 5309 (delta 1475), pack-reused 0
Receiving objects: 100% (7024/7024), 408.47 MiB | 904.00 KiB/s, done.
Resolving deltas: 100% (1746/1746), done.
Note: checking out 'ee79e8bb6723380d3b6b794e81192d4035c1097b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

Checking out files: 100% (6913/6913), done.
```

Download Sizeが1.89 GiBから408.47 MiBに激減した(それでもデカすぎませんかね、of...)。

# git cloneはclone先のdirectoryを指定できるからmkdirもcpも不要だ

どうも
https://github.com/Lacty/ToTheTop/blob/65d3682f0aaeda3dfaafe23ac16d4e7f6c338845/.travis.yml
をみると

```sh
$git clone https://github.com/jefftimesten/ofxJSON.git
$cp -r ofxJSON openFrameworks/addons/
```

のような摩訶不思議なことをやっている。なんだその``cp``は。
せめて``mv``しろよ！

そもそも論

```
SYNOPSIS
       git clone [--template=<template_directory>]
                 [-l] [-s] [--no-hardlinks] [-q] [-n] [--bare] [--mirror]
                 [-o <name>] [-b <name>] [-u <upload-pack>] [--reference <repository>]
                 [--dissociate] [--separate-git-dir <git dir>]
                 [--depth <depth>] [--[no-]single-branch]
                 [--recursive | --recurse-submodules] [--[no-]shallow-submodules]
                 [--jobs <n>] [--] <repository> [<directory>]
```

のようにdirectoryは指定できる。

# このrepo自体のclone depthもいじろう

Customizing the Build - Travis CI
https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth

```yml
git:
  depth: 3
```

のようにいじれる。