### PR TITLE
warpZone プレイヤーの操作と重力をワープ開始時に切るようにしました

### DIFF
--- a/src/Actors/WarpZone/warpManager.h
+++ b/src/Actors/WarpZone/warpManager.h
@@ -16,7 +16,7 @@ private:
 	shared_ptr<Actor> player_;
 	ofVec2f spawnPos_;
 	ofVec2f destPos_;
-	const float limitPos_ = 200;
+	const float limitPos_ = g_local->Height();
 	const float spwPosXMin_ = 100;
 	const float spwPosXMax_ = g_local->Width() - 100;
 	void spawnWarp();

--- a/src/Actors/WarpZone/warpZone.cpp
+++ b/src/Actors/WarpZone/warpZone.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "precompiled.h"
 
 
@@ -35,6 +35,8 @@ void WarpZone::update(float deltaTime) {
 
 	player_->setPos(ofVec2f(x_, y_));
 	if (destPos_ == ofVec2f(x_, y_)) {
+		player_->canControl(true);
+		player_->addVelocity(true);
 		destroy();
 	}
 }
@@ -49,6 +51,8 @@ void WarpZone::onCollision(Actor* c_actor) {
 	if (c_actor->getTag() == PLAYER) {
 		color_ = ofFloatColor(0, 0, 0, 0);
 		player_ = dynamic_cast<Player*>(c_actor);
+		player_->canControl(false);
+		player_->addVelocity(false);
 		enableUpdate();
 	}
 }


### PR DESCRIPTION
ワープが終わった後は元に戻してます
warpManagerのlimitPosも引き上げました(ワープ中にdestroy()してしまうため)