### PR TITLE
[Refactor]fix compiler warning

### DIFF
--- a/src/Actors/Player/movingState.cpp
+++ b/src/Actors/Player/movingState.cpp
@@ -92,7 +92,7 @@ void MovingState::onCollision(Player* player, Actor* c_actor) {
     auto p_vel  = player->getVel();
     auto p_size = player->getSize();
     auto c_pos  = c_actor->getPos();
-    auto c_vel  = c_actor->getVel();
+    //auto c_vel  = c_actor->getVel();
     auto c_size = c_actor->getSize();
 
     // Playerの上辺がBrickの底辺とCollisionした場合

--- a/src/Actors/Player/standingState.cpp
+++ b/src/Actors/Player/standingState.cpp
@@ -65,7 +65,7 @@ void StandingState::onCollision(Player* player, Actor* c_actor) {
     auto p_vel  = player->getVel();
     auto p_size = player->getSize();
     auto c_pos  = c_actor->getPos();
-    auto c_vel  = c_actor->getVel();
+    //auto c_vel  = c_actor->getVel();
     auto c_size = c_actor->getSize();
 
     // Standing状態はonFloorがtrueの時しかありえないので条件文を省略

--- a/src/Actors/Player/stateManager.h
+++ b/src/Actors/Player/stateManager.h
@@ -16,7 +16,7 @@ class StateBase;
 class StateManager {
 private:
   const int MAX_STACK    = 10; ///< 管理する状態の最大数(スタック)
-  const int MAX_PARALLEL = 5;  ///< 管理する状態の最大数(並列)
+  //const int MAX_PARALLEL = 5;  ///< 管理する状態の最大数(並列)
   
   using p_state = shared_ptr<StateBase>;
   

--- a/src/Actors/Player/teleportState.cpp
+++ b/src/Actors/Player/teleportState.cpp
@@ -55,7 +55,7 @@ void TeleportState::onCollision(Player* player, Actor* c_actor) {
   auto p_vel  = player->getVel();
   auto p_size = player->getSize();
   auto c_pos  = c_actor->getPos();
-  auto c_vel  = c_actor->getVel();
+  //auto c_vel  = c_actor->getVel();
   auto c_size = c_actor->getSize();
 
   // Brick以外の物と判定しないように制限

--- a/src/Actors/Player/teleportState.cpp
+++ b/src/Actors/Player/teleportState.cpp
@@ -127,7 +127,7 @@ void TeleportState::movePos(float deltaTime, Player* player, ofxJoystick& input)
   auto c_size  = cursor_->getSize();
   auto c_speed = cursor_->getSpeed();
   auto p_pos   = player->getPos();
-  auto p_vel   = player->getVel();
+  //auto p_vel   = player->getVel();
   auto p_size  = player->getSize();
 
   // カーソルとプレイヤーの中心座標

--- a/src/Actors/actor.cpp
+++ b/src/Actors/actor.cpp
@@ -28,10 +28,10 @@ Actor::Actor()
   : uid_            ( generateUid() )
   , name_           ( "NoName"      )
   , tag_            ( -1            )
-  , destroy_        ( false         )
   , finishSetup_    ( false         )
   , enableUpdate_   ( false         )
   , enableCollision_( false         )
+  , destroy_        ( false         )
 {}
 
 // ---------------------------------------------------------------------

--- a/src/Actors/actor.cpp
+++ b/src/Actors/actor.cpp
@@ -26,9 +26,9 @@ uintmax_t Actor::generateUid() {
  */
 Actor::Actor()
   : uid_            ( generateUid() )
+  , finishSetup_    ( false         )
   , name_           ( "NoName"      )
   , tag_            ( -1            )
-  , finishSetup_    ( false         )
   , enableUpdate_   ( false         )
   , enableCollision_( false         )
   , destroy_        ( false         )

--- a/src/Actors/spawner.cpp
+++ b/src/Actors/spawner.cpp
@@ -20,8 +20,8 @@ Spawner::Spawner()
 
 Spawner::Spawner(const shared_ptr<Actor>& act, float timer)
   : actor_    ( act   )
-  , deltaTime_( 0     )
   , spawnTime_( timer )
+  , deltaTime_( 0     )
 {
   name_ = "Spawner";
   tag_  =  SPAWNER ;

--- a/src/BackGround/backGround.cpp
+++ b/src/BackGround/backGround.cpp
@@ -168,12 +168,12 @@ Star::Star(const ofVec3f& pos, const ofVec3f& vel, const ofFloatColor& color,
            float width, float height)
   : pos_   (pos   )
   , vel_   (vel   )
-  , color_ (color )
   , extend_(extend)
   , shrink_(shrink)
   , clause_(clause)
   , width_ (width )
   , height_(height)
+  , color_ (color )
 {}
 
 void Star::update(float deltaTime) {

--- a/src/UserInterface/uiBase.cpp
+++ b/src/UserInterface/uiBase.cpp
@@ -11,11 +11,11 @@
 
 
 uiBase::uiBase()
-  : name_         ( "NoName" )
+  : enableUpdate_ ( false    )
+  , finishSetup_  ( false    )
+  , name_         ( "NoName" )
   , tag_          ( -1       )
   , isDead_       ( false    )
-  , enableUpdate_ ( false    )
-  , finishSetup_  ( false    )
 {}
 
 /**

--- a/src/UserInterface/uiBase.cpp
+++ b/src/UserInterface/uiBase.cpp
@@ -11,8 +11,8 @@
 
 
 uiBase::uiBase()
-  : enableUpdate_ ( false    )
-  , finishSetup_  ( false    )
+  : finishSetup_  ( false    )
+  , enableUpdate_ ( false    )
   , name_         ( "NoName" )
   , tag_          ( -1       )
   , isDead_       ( false    )

--- a/src/gameLocal.cpp
+++ b/src/gameLocal.cpp
@@ -15,11 +15,11 @@ unique_ptr<GameLocal> g_local = make_unique<GameLocal>();
 
 
 GameLocal::GameLocal()
-  : Stop      ( false )
-  , width_    ( 0     )
+  : width_    ( 0     )
   , height_   ( 0     )
   , lastFrame_( 0     )
   , frameAcc_ ( 0     )
+  , Stop      ( false )
 {}
 
 void GameLocal::Setup() {


### PR DESCRIPTION
コンストラクタの初期化文はclassでのメンバーの宣言順にしましょう。というお話。
初期化の順番に依存性がある書き方をしないために習慣的に気をつけるべき。